### PR TITLE
Ordered SubPorts

### DIFF
--- a/src/Arrows.jl
+++ b/src/Arrows.jl
@@ -254,6 +254,7 @@ include("optim/optimize.jl")
 # Examples, etc #
 include("targets/targets.jl")
 include("targets/julia/JuliaTarget.jl")
+include("targets/julia/ordered_sports.jl")
 # include("targets/tensorflow/tensorflow.jl") # TODO Make optional
 
 include("apply/call.jl")

--- a/src/Arrows.jl
+++ b/src/Arrows.jl
@@ -179,7 +179,10 @@ export
 
   # Optim
   julia,
-  id_loss
+  id_loss,
+
+  # compiler
+  order_sports
 # Code structures
 
 include("util/misc.jl")             # miscelleneous utilities

--- a/src/targets/julia/ordered_ports.jl
+++ b/src/targets/julia/ordered_ports.jl
@@ -1,0 +1,39 @@
+import Base: Iterators
+
+#TODO: remove the Arrows.
+
+ordered_values(carr::Arrow, ::Set{Arrows.CompArrow}) = []
+
+function ordered_values1(carr::CompArrow)
+  ordered_values(carr, Set{Arrows.CompArrow}())
+end
+
+function ordered_values(carr::CompArrow, seen::Set{Arrows.CompArrow})
+  push!(seen, carr)
+  assigns = Vector{Arrows.SrcValue}()
+  function f(sarr::SubArrow, args)
+    outnames = map(name, Arrows.out_values(sarr))
+    for value in Arrows.out_values(sarr)
+      if value ∉ assigns
+        push!(assigns, value)
+      end
+    end
+    outnames
+  end
+
+  inputs = map(name, Arrows.in_values(sub_arrow(carr)))
+  interpret(f, carr, inputs)
+  answer = Vector{Vector{Arrows.SrcValue}}()
+  to_arrow = Arrows.deref ∘ Arrows.sub_arrow ∘ Arrows.src
+  for value in assigns
+    prev = to_arrow(value)
+    if prev ∉ seen
+      ordered = ordered_values(to_arrow(value), seen)
+      if !isempty(ordered)
+        push!(answer, ordered)
+      end
+    end
+    push!(answer, [value,])
+  end
+  collect(Iterators.flatten(answer))
+end

--- a/src/targets/julia/ordered_ports.jl
+++ b/src/targets/julia/ordered_ports.jl
@@ -48,18 +48,31 @@ function parent_value{T}(::Arrows.Port{Arrows.Arrow, T},
   default
 end
 
-function ordered_values(carr::CompArrow)
+function order_values(carr::CompArrow)
   assigments = order_of_assigment(carr)
-  answer = Dict{Arrows.SrcValue, Int}()
-
-  for (idx, value) in enumerate(assigments)
+  order = Dict{Arrows.SrcValue, Int}()
+  idx = 1
+  for value in assigments
     sport = Arrows.src(value)
     p_value = parent_value(deref(sport), value)
-    if p_value ∈ keys(answer)
-      answer[value] = answer[p_value]
+    if p_value ∈ keys(order)
+      order[value] = order[p_value]
     else
-      answer[value] = idx
+      order[value] = idx
+      idx += 1
     end
   end
-  sort(collect(answer), by=x->x[2])
+  order
+end
+
+function order_sub_ports(carr::CompArrow, sports::Vector{SubPort})
+  ordered_values = order_values(carr)
+  pairs = Vector{Pair{Int, Int}}()
+  for (idx, sport) in enumerate(sports)
+    value = Arrows.SrcValue(sport)
+    position = ordered_values[value]
+    push!(pairs, idx=>position)
+  end
+  sorted_pairs = sort(pairs, by=x->x[2])
+  map(first, pairs)
 end

--- a/src/targets/julia/ordered_sports.jl
+++ b/src/targets/julia/ordered_sports.jl
@@ -70,7 +70,7 @@ end
 
 """Given a `CompArrow` and a `Vecotr{SubPort}`, return the order in which the
   elements of the vector are computed"""
-function order_sub_ports(carr::CompArrow, sports::Vector{SubPort})
+function order_sports(carr::CompArrow, sports::Vector{SubPort})
   ordered_values = order_values(carr)
   pairs = Vector{Pair{Int, Int}}()
   for (idx, sport) in enumerate(sports)
@@ -79,5 +79,5 @@ function order_sub_ports(carr::CompArrow, sports::Vector{SubPort})
     push!(pairs, idx=>position)
   end
   sorted_pairs = sort(pairs, by=x->x[2])
-  map(first, pairs)
+  map(first, sorted_pairs)
 end

--- a/src/targets/julia/ordered_sports.jl
+++ b/src/targets/julia/ordered_sports.jl
@@ -45,7 +45,7 @@ function parent_value{T}(port::Port{CompArrow, T},
   (SrcValue ∘ sub_port)(port)
 end
 
-function parent_value{T}(::Port{Arrow, T},
+function parent_value{T1, T2}(::Port{T1, T2},
                         default::SrcValue)
   default
 end

--- a/test/tests/ordered_sports.jl
+++ b/test/tests/ordered_sports.jl
@@ -9,10 +9,10 @@ function test_ordered()
   s_star, s_plus = sub_arrows(carr)
   sport1 = sub_ports(s_plus)[3]
   sport2 = sub_ports(s_star)[3]
-  z = sub_ports(carr)
+  z = sub_ports(carr)[3]
   sports = [sport1, sport2, z]
   order = order_sports(carr, sports)
   @test sports[order] == [sport2, sport1, z]
 end
 
-test_propagate()
+test_ordered()

--- a/test/tests/ordered_sports.jl
+++ b/test/tests/ordered_sports.jl
@@ -1,0 +1,18 @@
+using Arrows
+using Arrows.TestArrows
+using Base.Test
+
+
+
+function test_ordered()
+  carr = TestArrows.xy_plus_x_arr()
+  s_star, s_plus = sub_arrows(carr)
+  sport1 = sub_ports(s_plus)[3]
+  sport2 = sub_ports(s_star)[3]
+  z = sub_ports(carr)
+  sports = [sport1, sport2, z]
+  order = order_sports(carr, sports)
+  @test sports[order] == [sport2, sport1, z]
+end
+
+test_propagate()


### PR DESCRIPTION
Given an `Arrow` and a list of `SubPorts`,  `order_sports` return the order in which the `SubPorts` are computed