### PR TITLE
Using filters

### DIFF
--- a/benchmarks/kinematics/kinematics.jl
+++ b/benchmarks/kinematics/kinematics.jl
@@ -124,14 +124,14 @@ end
 function fwd_2d_linkage(nlinks::Integer)
   inp_names = [Symbol(:ϕ_, i) for i=1:nlinks]
   carr = CompArrow(:fwd_kin, inp_names, [:x, :y])
-  angles = in_sub_ports(carr)
+  angles = ▹(carr)
   curr_angle = first(angles)
   sum_angles = [curr_angle]
   for i = 2:nlinks
     addarr = add_sub_arr!(carr, AddArrow())
     link_ports!(curr_angle, (addarr, 1))
     link_ports!(angles[i], (addarr, 2))
-    curr_angle = out_sub_port(addarr, 1)
+    curr_angle = ◃(addarr, 1)
     push!(sum_angles, curr_angle)
   end
 
@@ -149,7 +149,7 @@ function fwd_2d_linkage(nlinks::Integer)
     link_ports!((cosarr, 1), (total_cos, i))
   end
 
-  x, y = out_sub_ports(carr)
+  x, y = ◃(carr)
   link_ports!((total_sin, 1), x)
   link_ports!((total_cos, 1), y)
   carr
@@ -159,14 +159,14 @@ end
 function fwd_2d_linkage_obs(nlinks::Integer)
   inp_names = [Symbol(:ϕ_, i) for i=1:nlinks]
   carr = CompArrow(:fwd_kin, inp_names, [:x, :y])
-  angles = in_sub_ports(carr)
+  angles = ▹(carr)
   curr_angle = first(angles)
   sum_angles = [curr_angle]
   for i = 2:nlinks
     addarr = add_sub_arr!(carr, AddArrow())
     link_ports!(curr_angle, (addarr, 1))
     link_ports!(angles[i], (addarr, 2))
-    curr_angle = out_sub_port(addarr, 1)
+    curr_angle = ◃(addarr, 1)
     push!(sum_angles, curr_angle)
   end
 
@@ -177,7 +177,7 @@ function fwd_2d_linkage_obs(nlinks::Integer)
     link_ports!((sinarr, 1), (total_sin, i))
   end
 
-  midsumxs = out_sub_ports(total_sin)[2:end]
+  midsumxs = ◃(total_sin)[2:end]
 
   total_cos = add_sub_arr!(carr, Arrows.addn_accum_linke(length(sum_angles)))
   for (i, angle) in enumerate(sum_angles)
@@ -186,11 +186,11 @@ function fwd_2d_linkage_obs(nlinks::Integer)
     link_ports!((cosarr, 1), (total_cos, i))
   end
 
-  midsumys = out_sub_ports(total_cos)[2:end]
+  midsumys = ◃(total_cos)[2:end]
 
   @show midsumys, midsumxs
 
-  x, y = out_sub_ports(carr)
+  x, y = ◃(carr)
   link_ports!((total_sin, 1), x)
   link_ports!((total_cos, 1), y)
 

--- a/src/apply/interpret.jl
+++ b/src/apply/interpret.jl
@@ -14,7 +14,7 @@ end
 "Decrement SubArrows "
 function known_colors(carr::CompArrow)::ArrowColors
   pq = colors(carr)
-  foreach(out_neighbors(in_sub_ports(carr))) do dst_sprt
+  foreach(out_neighbors(▹(carr))) do dst_sprt
     lower!(pq, sub_arrow(dst_sprt))
   end
   pq
@@ -25,7 +25,7 @@ function dst_sub_port_values(carr::CompArrow, inputs::Vector)::Dict{SubPort, Any
   length(inputs) == num_in_ports(carr) || throw(DomainError())
   dst_val = Dict{SubPort, Any}()
 
-  for (i, sprt) in enumerate(in_sub_ports(carr))
+  for (i, sprt) in enumerate(▹(carr))
     for dst_sprt in out_neighbors(sprt)
       dst_val[dst_sprt] = inputs[i]
     end
@@ -48,14 +48,14 @@ function inner_interpret(sub_interpret,
     @assert peek(arrcolors)[2] == 0 peek(arrcolors)[2]
     sarr = dequeue!(arrcolors)
     push!(seen, sarr)
-    inputs = [dst_val[sprt] for sprt in in_sub_ports(sarr)]
+    inputs = [dst_val[sprt] for sprt in ▹(sarr)]
     outputs = sub_interpret(sarr, inputs)
 
-    @assert length(outputs) == length(out_ports(sarr)) "diff num outputs"
+    @assert length(outputs) == length(◂(sarr)) "diff num outputs"
 
     # Decrement the priority of each subarrow connected to this arrow
     # Unless of course it is connected to the outside word
-    for (i, sprt) in enumerate(out_sub_ports(sarr))
+    for (i, sprt) in enumerate(◃(sarr))
       for dst_sprt in out_neighbors(sprt)
         dst_val[dst_sprt] = outputs[i]
         # @assert sub_arrow(dst_sprt) ∈ keys(arrcolors)
@@ -64,7 +64,7 @@ function inner_interpret(sub_interpret,
     end
   end
 
-  [dst_val[sprt] for sprt in out_sub_ports(carr)]
+  [dst_val[sprt] for sprt in ◃(carr)]
 end
 
 """

--- a/src/arrows/comparrowextra.jl
+++ b/src/arrows/comparrowextra.jl
@@ -1,11 +1,11 @@
 "All source (projecting) sub_ports"
-src_sub_ports(arr::CompArrow)::Vector{SubPort} = filter(is_src, sub_ports(arr))
+src_sub_ports(arr::CompArrow)::Vector{SubPort} = ⬨(arr, is_src)
 
 "All source (projecting) sub_ports"
 all_src_sub_ports(arr::CompArrow)::Vector{SubPort} = filter(is_src, all_sub_ports(arr))
 
 "All destination (receiving) sub_ports"
-dst_sub_ports(arr::CompArrow)::Vector{SubPort} = filter(is_dst, sub_ports(arr))
+dst_sub_ports(arr::CompArrow)::Vector{SubPort} = ⬨(arr, is_dst)
 
 "All source (projecting) sub_ports"
 all_dst_sub_ports(arr::CompArrow)::Vector{SubPort} = filter(is_dst, all_sub_ports(arr))
@@ -17,7 +17,7 @@ in(sport::SubPort, arr::CompArrow) = sport ∈ fall_sub_ports(arr)
 in(link::Link, arr::CompArrow) = link ∈ links(arr)
 
 "Is `sport` a boundary `SubPort` (i.e. not `SubPort` of inner `SubArrow`)"
-is_boundary(sprt::SubPort) = sprt ∈ sub_ports(sub_arrow(sprt))
+is_boundary(sprt::SubPort) = sprt ∈ ⬨(sub_arrow(sprt))
 
 "Is `port` within `arr` but not on boundary"
 strictly_in(sprt::SubPort, arr::CompArrow) = sprt ∈ inner_sub_ports(arr)
@@ -59,10 +59,10 @@ promote_right_port(port::Port) = promote_port(port)
 # # TODO: DomainError not assert
 # @assert parent(r) == c
 src_port(src_arr::SubArrow, src_id) =
-  self_parent(src_arr) ? in_sub_port(src_arr, src_id) : out_sub_port(src_arr, src_id)
+  self_parent(src_arr) ? ▹(src_arr, src_id) : ◃(src_arr, src_id)
 
 dst_port(dst_arr::SubArrow, dst_id) =
-  self_parent(dst_arr) ? out_sub_port(dst_arr, dst_id) : in_sub_port(dst_arr, dst_id)
+  self_parent(dst_arr) ? ◃(dst_arr, dst_id) : ▹(dst_arr, dst_id)
 
 promote_left_port(pid::Tuple{SubArrow, <:Integer}) = src_port(pid...)
 promote_right_port(pid::Tuple{SubArrow, <:Integer}) = dst_port(pid...)
@@ -90,7 +90,7 @@ function replace_sub_arr!(sarr::SubArrow, arr::Arrow, portidmap::PortIdMap)::Sub
   parr = parent(sarr)
   replarr = add_sub_arr!(parr, arr)
   subportmap = sub_port_map(sarr, replarr, portidmap)
-  for sport in sub_ports(sarr)
+  for sport in ⬨(sarr)
     for (l, r) in in_links(sport)
       link_ports!(l, subportmap[r])
     end
@@ -319,7 +319,7 @@ link_to_parent!(sprts::Vector{SubPort}, pred) =
 # FIXME: Deprecate in favour of sub_arrow filter
 "Link all `sprt::SubPort ∈ sarr` to parent if preds(sprt)"
 link_to_parent!(sarr::SubArrow, pred) =
-  link_to_parent!(sub_ports(sarr), pred)
+  link_to_parent!(⬨(sarr), pred)
 
 # FIXME: Deprecate this in favour of convenient syntax for filter vector ports
 "Link `sprt::SubPort ∈ sarr` to parent if `pred(sprt)``"
@@ -333,7 +333,7 @@ n▸ = num_in_ports
 n◂ = num_out_ports
 
 ## Printing ##
-# FIXME: rename mann to something meaningful 
+# FIXME: rename mann to something meaningful
 function mann(carr::CompArrow; kwargs...)
   """$(func_decl(carr; kwargs...))
   $(num_sub_arrows(carr)) sub arrows

--- a/src/combinators/compose.jl
+++ b/src/combinators/compose.jl
@@ -100,10 +100,10 @@ end
 
 "∀ src -> dst ∈ orig"
 function inner_compose!(orig::SubArrow, sarr::SubArrow)
-  dsts = in_sub_ports(orig)
+  dsts = ▹(orig)
   srcs = src.(dsts)
-  as = in_sub_ports(sarr)
-  bs = out_sub_ports(sarr)
+  as = ▹(sarr)
+  bs = ◃(sarr)
   same(map(length, [srcs, dsts, as, bs])) || throw(DomainError())
   foreach(replace_link!, srcs, dsts, as, bs)
   bs

--- a/src/compile/depend.jl
+++ b/src/compile/depend.jl
@@ -3,12 +3,12 @@ CondMap = Dict{SubPort, Bool}
 
 "`Value`s in `arr` needed to compute outputs of `subarr`"
 function needed_values(::Arrow, subarr::SubArrow, cond_map::CondMap)::ValueSet
-  Set(SrcValue.(in_sub_ports(subarr)))
+  Set(SrcValue.(▹(subarr)))
 end
 
 "`Value`s in `arr` needed to compute outputs of `subarr`"
 function needed_values(::CondArrow, subarr::SubArrow, cond_map::CondMap)::ValueSet
-  i, t, e = in_sub_ports(subarr)
+  i, t, e = ▹(subarr)
   if i in cond_map
     if cond_map[i]
       Set(SrcValue(t))

--- a/src/host/overload.jl
+++ b/src/host/overload.jl
@@ -3,7 +3,7 @@
 promote_constant(carr::CompArrow, sprt::SubPort) = sprt
 function promote_constant(carr::CompArrow, x)
   sarr = add_sub_arr!(carr, SourceArrow(x))
-  out_sub_port(sarr, 1)
+  ◃(sarr, 1)
 end
 
 function inner(ArrType, xs::Vararg{SubPort})
@@ -14,7 +14,7 @@ function inner(ArrType, xs::Vararg{SubPort})
   for (i, x) in enumerate(xs)
     link_ports!(x, (sarr, i))
   end
-  output = out_sub_ports(sarr)
+  output = ◃(sarr)
   if length(output) == 1
     output[1]
   else

--- a/src/library/compound.jl
+++ b/src/library/compound.jl
@@ -2,14 +2,14 @@
 function addn_accum(n::Integer)
   inp_names = [Symbol(:ϕ_, i) for i=1:n]
   carr = CompArrow(:addn, inp_names, [:sum])
-  vals = in_sub_ports(carr)
+  vals = ▹(carr)
   curr_val = first(vals)
   sum_vals = [curr_val]
   for i = 2:n
     addarr = add_sub_arr!(carr, AddArrow())
     link_ports!(curr_val, (addarr, 1))
     link_ports!(vals[i], (addarr, 2))
-    curr_val = out_sub_port(addarr, 1)
+    curr_val = ◃(addarr, 1)
     push!(sum_vals, curr_val)
   end
   link_ports!(curr_val, (carr, 1))

--- a/src/library/inv_arith.jl
+++ b/src/library/inv_arith.jl
@@ -1,8 +1,8 @@
 "Inverse Addition"
 function inv_add()
   c = CompArrow(:inv_add, [:z, :θadd], [:x, :y])
-  z, θ = in_ports(c)
-  x, y = out_ports(c)
+  z, θ = ▸(c)
+  x, y = ◂(c)
   addprop!(θp, θ)
   subtract = add_sub_arr!(c, SubtractArrow())
   link_ports!(z, (subtract, 1))
@@ -15,7 +15,7 @@ end
 "Inverse Subtraction"
 function inv_sub()
   carr = CompArrow(:inv_sub, [:z, :θsub], [:x, :y])
-  z, θ, x, y = sub_ports(carr)
+  z, θ, x, y = ⬨(carr)
   addprop!(θp, deref(θ))
   (z + θ) ⥅ x
   θ ⥅ y
@@ -25,8 +25,8 @@ end
 "Inverse multiplication"
 function inv_mul()
   c = CompArrow(:inv_mul, [:z, :θmul], [:x, :y])
-  z, θ = in_ports(c)
-  x, y = out_ports(c)
+  z, θ = ▸(c)
+  x, y = ◂(c)
   div = add_sub_arr!(c, DivArrow())
   addprop!(θp, θ)
   link_ports!(z, (div, 1))

--- a/src/library/pgfprim.jl
+++ b/src/library/pgfprim.jl
@@ -7,7 +7,7 @@
 function pgf(arr::MulArrow)
   "As f^(-1)(z; θ) = (z/θ, θ), then the pgf becomes r(x, y) = (x*y, y)."
   carr = CompArrow(Symbol(:pgf_, :mul), [:x, :y], [:z, :θ])
-  x, y, z, θ = sub_ports(carr)
+  x, y, z, θ = ⬨(carr)
   x * y ⥅ z
   y ⥅ θ
   carr
@@ -16,7 +16,7 @@ end
 function pgf(arr::AddArrow)
   "As f^(-1)(z; θ) = (z-θ, θ), then the pgf becomes r(x, y) = (x+y, y)."
   carr = CompArrow(Symbol(:pgf_, :add), [:x, :y], [:z, :θ])
-  x, y, z, θ = sub_ports(carr)
+  x, y, z, θ = ⬨(carr)
   x + y ⥅ z
   y ⥅ θ
   carr
@@ -25,7 +25,7 @@ end
 function pgf(arr::SubArrow)
   "As f^(-1)(z; θ) = (z+θ, θ), then the pgf becomes r(x, y) = (x-y, y)."
   carr = CompArrow(Symbol(:pgf_, :sub), [:x, :y], [:z, :θ])
-  x, y, z, θ = sub_ports(carr)
+  x, y, z, θ = ⬨(carr)
   x - y ⥅ z
   y ⥅ θ
   carr
@@ -34,7 +34,7 @@ end
 function pgf(arr::SinArrow)
   "As f^(-1)(y; θ) = , then the pgf becomes "
   carr = CompArrow(Symbol(:pgf_, :sin), [:x], [:y, :θ])
-  x, y, θ = sub_ports(carr)
+  x, y, θ = ⬨(carr)
   sinarr = add_sub_arr!(carr, SinArrow())
   link_ports!(x, (sinarr, 1))
   link_ports!((sinarr, 1), y)
@@ -46,7 +46,7 @@ end
 function pgf(arr::CosArrow)
   "As f^(-1)(y; θ) = 2πθ + (-1)^θ * acos(y), then the pgf becomes "
   carr = CompArrow(Symbol(:pgf_, :cos), [:x], [:y, :θ])
-  x, y, θ = sub_ports(carr)
+  x, y, θ = ⬨(carr)
   cosarr = add_sub_arr!(carr, CosArrow())
   link_ports!(x, (cosarr, 1))
   link_ports!((cosarr, 1), y)
@@ -72,7 +72,7 @@ end
 function pgf(arr::LessThanArrow)
   "As f^(-1)(z; θ1, θ2) = (θ1, [θ1+θ2, θ1-θ2]^z), then the pgf becomes r(x, y) = (x<y, x, abs(x-y))."
   carr = CompArrow(Symbol(:pgf_, :lessthan), [:x, :y], [:z, :θ1, :θ2])
-  x, y, z, θ1, θ2 = sub_ports(carr)
+  x, y, z, θ1, θ2 = ⬨(carr)
   abs = add_sub_arr!(carr, AbsArrow())
   x < y ⥅ z
   x ⥅ θ1

--- a/src/macros/arr_macro.jl
+++ b/src/macros/arr_macro.jl
@@ -145,11 +145,11 @@ function transform_function(expr)
                                     (func_(args__; kwargs__)::rtype_) |
                                     (func_(args__)) |
                                     (func_(args__)::rtype_)))
-  args = [splitvar(var)[1] for var in args]                                  
+  args = [splitvar(var)[1] for var in args]
   args = [Symbol(s) for s in args]
   name = Symbol(args...)
   carr = CompArrow(name, args, [:z])
-  sports = sub_ports(carr)
+  sports = ⬨(carr)
   z = sports[end]
   context = Dict([k=> v for (k,v) in zip(args, sports[1:end-1])])
   osprt = transform_expr!(body, context, carr)

--- a/src/optim/loss.jl
+++ b/src/optim/loss.jl
@@ -2,7 +2,7 @@
 function diff_arrow()
   carr = SubtractArrow() >> SqrArrow() >> SqrtArrow()
   rename!(carr, :diff)
-  set_error_port!(out_port(carr, 1))
+  set_error_port!(◂(carr, 1))
   carr
 end
 
@@ -14,7 +14,7 @@ end
 function meanerror(invarr::CompArrow)
   thebest = CompArrow(:thebest)
   sarr = add_sub_arr!(thebest, invarr)
-  ϵprts = filter(is(ϵ), ◂(invarr))
+  ϵprts = ◂(invarr, is(ϵ))
   meanarr = add_sub_arr!(thebest, MeanArrow(length(ϵprts)))
   i = 1
   foreach(Arrows.link_to_parent!, ▹(sarr))
@@ -58,7 +58,7 @@ function id_loss!(fwd::Arrow, inv::Arrow)::Arrow
   invsarr = add_sub_arr!(carr, inv)
   fwdsarr = add_sub_arr!(carr, fwd)
 
-  osports = out_sub_ports(invsarr)
+  osports = ◃(invsarr)
   error_port = is(ϵ) ∘ deref
   for (i, sprt) in enumerate(filter(!error_port, osports))
     sprt ⥅ (fwdsarr, i)

--- a/src/targets/tensorflow/to_arrow.jl
+++ b/src/targets/tensorflow/to_arrow.jl
@@ -103,7 +103,7 @@ function graph_to_arrow(name::Symbol,
   c = CompArrow(name, I, O)
 
   # Make an in_port for every input ten
-  ten_in_port = Dict{AbstractTensor, SubPort}(zip(inp_tens, in_sub_ports(c)))
+  ten_in_port = Dict{AbstractTensor, SubPort}(zip(inp_tens, ▹(c)))
   for inp in inp_tens
     ten_in_port[inp]
   end

--- a/src/transform/compcall.jl
+++ b/src/transform/compcall.jl
@@ -14,16 +14,16 @@ function unlinkcall(f, name::ArrowName, sprts::SubPort...)::Tuple{SubPort}
   pprops = map(sprt -> Props(props(sprt); is_in_port=true), src_sprts)
   carr = CompArrow(name, [pprops...])
   # 2. Break all the kinks
-  f_outs = s(f(in_sub_ports(carr)...))
+  f_outs = s(f(▹(carr)...))
   # foreach(link_to_parent!, s(f(in_sub_ports(carr)...)))
   # 3. add carr to the parent, link sprts to in_ports of carr and return outports
   sarr = add_sub_arr!(parent_carr, carr)
-  foreach(sprts, in_sub_ports(sarr)) do parent_sprt, inner_sprt, f_outs
+  foreach(sprts, ▹(sarr)) do parent_sprt, inner_sprt, f_outs
     unlink_ports!(src(parent_sprt), parent_sprt)
     src(parent_sprt) ⥅ inner_sprt
     fouts ⥅ parent_sprt
   end
-  tuple(out_sub_ports(sarr)...)
+  tuple(◃(sarr)...)
 end
 
 unlinkcall(f, sprts::SubPort...) = unlinkcall(f, typeof(f).name.name, (sprts...))

--- a/src/transform/invert.jl
+++ b/src/transform/invert.jl
@@ -10,8 +10,8 @@ end
 # Hack until constant propagation is done
 function inv(sarr::SubArrow)
   carr = deref(sarr)
-  const_in = map(is_src_source, in_sub_ports(sarr))
-  for sprt in in_sub_ports(sarr)
+  const_in = map(is_src_source, ▹(sarr))
+  for sprt in ▹(sarr)
     arr = deref(src(sprt)).arrow
     if isa(arr, SourceArrow)
       @show arr.value

--- a/src/transform/invprim.jl
+++ b/src/transform/invprim.jl
@@ -87,7 +87,7 @@ inv(arr::LessThanArrow, const_in::Vector{Bool}) = (inv_lt_arr(), Dict(1 => 4, 2 
 
 function inv_gt_arr()
   carr = CompArrow(:inv_gt, [:z, :y, :θinv_gt_arr], [:x])
-  z, y, θ, x = sub_ports(carr)
+  z, y, θ, x = ⬨(carr)
   addprop!(θp, deref(θ))
   assert!(z)
   (abs(θ) + y) ⥅ x
@@ -96,7 +96,7 @@ end
 
 function inv_lt_arr()
   carr = CompArrow(:inv_gt, [:z, :y, :θinv_lt_arr], [:x])
-  z, y, θ, x = sub_ports(carr)
+  z, y, θ, x = ⬨(carr)
   addprop!(θp, deref(θ))
   assert!(z)
   (y - abs(θ)) ⥅ x

--- a/src/transform/totalizeprim.jl
+++ b/src/transform/totalizeprim.jl
@@ -10,7 +10,7 @@ end
 function bounded_totalize!(sarr::SubArrow)
   # TODO: Generalize this
   clipcarr = CompArrow(:clip, [:x], [:y])
-  x, y = sub_ports(clipcarr)
+  x, y = ⬨(clipcarr)
   bounds = domain_bounds(deref(sarr))
   clip(x, bounds...) ⥅ y
   inner_compose!(sarr, clipcarr)
@@ -18,7 +18,7 @@ end
 
 function nonneg_totalize!(sarr::SubArrow)
   clip_zero = CompArrow(:clip_zero, [:x], [:y])
-  x, y = sub_ports(clip_zero)
+  x, y = ⬨(clip_zero)
   max(x, 0) ⥅ y
   inner_compose!(sarr, clip_zero)
 end

--- a/src/value/source.jl
+++ b/src/value/source.jl
@@ -19,10 +19,10 @@ name(val::SrcValue) = Symbol(:val, :_, name(src(val)))
 sub_ports(val::SrcValue)::Vector{SubPort} = [src(val), out_neighbors(src(val))...]
 
 "Get Vector of InPort ValueSet"
-in_values(aarr::AbstractArrow)::Vector{SrcValue} = SrcValue.(in_sub_ports(aarr))
+in_values(aarr::AbstractArrow)::Vector{SrcValue} = SrcValue.(▹(aarr))
 
 "Get Vector of OutPort ValueSet"
-out_values(aarr::AbstractArrow)::Vector{SrcValue} = SrcValue.(out_sub_ports(aarr))
+out_values(aarr::AbstractArrow)::Vector{SrcValue} = SrcValue.(◃(aarr))
 
 "Get Vector of ValueSet"
-all_values(sarr::SubArrow)::Vector{SrcValue} = SrcValue.(sub_ports(sarr))
+all_values(sarr::SubArrow)::Vector{SrcValue} = SrcValue.(⬨(sarr))

--- a/test/TestArrows.jl
+++ b/test/TestArrows.jl
@@ -6,7 +6,7 @@ import Arrows: add_sub_arr!, in_sub_port, out_sub_port, inv_add, inv_mul
 "f(x) = sin(x)"
 function sin_arr()
   c = CompArrow(:x2, 1, 1)
-  x, y = ports(c)
+  x, y = ⬧(c)
   sinarr = add_sub_arr!(c, Arrows.SinArrow())
   x ⥅ (sinarr, 1)
   (sinarr, 1) ⥅ y
@@ -16,14 +16,14 @@ end
 "x * y + x"
 function xy_plus_x_arr()
   c = CompArrow(:xyx, [:x, :y], [:z])
-  x, y, z = ports(c)
+  x, y, z = ⬧(c)
   m2 = add_sub_arr!(c, MulArrow())
   add_arr = add_sub_arr!(c, AddArrow())
-  link_ports!(x, in_sub_port(m2, 1))
-  link_ports!(y, in_sub_port(m2, 2))
-  link_ports!(out_sub_port(m2, 1), in_sub_port(add_arr, 1))
-  link_ports!(x, in_sub_port(add_arr, 2))
-  link_ports!(out_sub_port(add_arr, 1), z)
+  x ⥅ (m2, 1)
+  y ⥅ (m2, 2)
+  (m2, 1) ⥅ (add_arr, 1)
+  x ⥅ (add_arr, 2)
+  (add_arr, 1) ⥅ z
   c
 end
 
@@ -31,23 +31,22 @@ xy_plus_x_jl(x, y) = x * y + x
 
 function inv_xy_plus_x_arr()
   carr = CompArrow(:inv_xy_plus_x, [:z, :θ], [:x, :y])
-  z, θ, x, y = sub_ports(carr)
+  z, θ, x, y = ⬨(carr)
   addprop!(θp, deref(θ))
   invadd = add_sub_arr!(carr, inv_add())
   invmul = add_sub_arr!(carr, inv_mul())
   invdupl = add_sub_arr!(carr, InvDuplArrow(2))
 
-  addz, addθ, addx, addy = sub_ports(invadd)
-  mulz, mulθ, mulx, muly = sub_ports(invmul)
-  sub_ports(invdupl)
-  link_ports!(z, addz)
-  link_ports!(addx, mulz)
-  link_ports!(θ, addθ)
-  link_ports!(addy, (invdupl, 1))
-  link_ports!(mulx, y)
-  link_ports!((invdupl, 1), x)
-  link_ports!(muly, (invdupl, 2))
-  link_ports!(θ, mulθ)
+  addz, addθ, addx, addy = ⬨(invadd)
+  mulz, mulθ, mulx, muly = ⬨(invmul)
+  z ⥅ addz
+  addx ⥅ mulz
+  θ ⥅ addθ
+  addy ⥅ (invdupl, 1)
+  mulx ⥅ y
+  (invdupl, 1) ⥅ x
+  muly ⥅ (invdupl, 2)
+  θ ⥅ mulθ
   carr
 end
 
@@ -55,7 +54,7 @@ end
 function fibonnaci_arr()
   c = CompArrow(:fib, 1, 1)
   c_wrap = add_sub_arr!(c, c)
-  x, y = ports(c)
+  x, y = ⬧(c)
   one = add_sub_arr!(c, SourceArrow(1))
   min = add_sub_arr!(c, SubtractArrow())
   ite = add_sub_arr!(c, CondArrow())
@@ -63,23 +62,23 @@ function fibonnaci_arr()
   add = add_sub_arr!(c, AddArrow())
 
   # if x == 1
-  link_ports!(x, in_sub_port(eq, 1))
-  link_ports!(out_sub_port(one, 1), in_sub_port(eq, 2))
-  link_ports!(out_sub_port(eq, 1), in_sub_port(ite, 1))
+  x ⥅ (eq, 1)
+  (one, 1) ⥅ (eq, 2)
+  (eq, 1) ⥅ (ite, 1)
 
   # return x
-  link_ports!(out_sub_port(one, 1), in_sub_port(ite, 2))
+  (one, 1) ⥅ (ite, 2)
 
   # f(x - 1)
-  link_ports!(x, in_sub_port(min, 1))
-  link_ports!(out_sub_port(one, 1), in_sub_port(min, 2))
-  link_ports!(out_sub_port(min, 1), in_sub_port(c_wrap, 1))
+  x ⥅ (min, 1)
+  (one, 1) ⥅ (min, 2)
+  (min, 1) ⥅ ▹(c_wrap, 1)
 
   # x + f(x - 1)
-  link_ports!(out_sub_port(c_wrap, 1), in_sub_port(add, 1))
-  link_ports!(x, in_sub_port(add, 2))
-  link_ports!(out_sub_port(add, 1), in_sub_port(ite, 3))
-  link_ports!(out_sub_port(ite, 1), y)
+  ◃(c_wrap, 1) ⥅ (add, 1)
+  x ⥅ (add, 2)
+  (add, 1) ⥅ (ite, 3)
+  (ite, 1) ⥅ y
   c
 end
 
@@ -90,11 +89,11 @@ function dupl_id_arr()
   c = CompArrow(:dupl_id, 1, 2)
   id1 = add_sub_arr!(c, IdentityArrow())
   id2 = add_sub_arr!(c, IdentityArrow())
-  x, y, z = ports(c)
-  link_ports!(x, in_sub_port(id1, 1))
-  link_ports!(x, in_sub_port(id2, 1))
-  link_ports!(out_sub_port(id1, 1), y)
-  link_ports!(out_sub_port(id2, 1), z)
+  x, y, z = ⬧(c)
+  x ⥅ (id1, 1)
+  x ⥅ (id2, 1)
+  (id1, 1) ⥅ y
+  (id2, 1) ⥅ z
   c
 end
 
@@ -106,37 +105,37 @@ function det_policy_inner_arr()
   g = add_sub_arr!(c, IdentityArrow())
   ite = add_sub_arr!(c, CondArrow())
 
-  link_ports!((c, 1), (p, 1))
-  link_ports!((p, 1), (c, 1))
-  link_ports!((p, 1), (ite, 1))
-  link_ports!((c, 1), (f, 1))
-  link_ports!((f, 1), (ite, 2))
-  link_ports!((f, 2), (g, 1))
-  link_ports!((g, 1), (ite, 3))
-  link_ports!((ite, 1), (c, 2))
+  (c, 1) ⥅ (p, 1)
+  (p, 1) ⥅ (c, 1)
+  (p, 1) ⥅ (ite, 1)
+  (c, 1) ⥅ (f, 1)
+  (f, 1) ⥅ (ite, 2)
+  (f, 2) ⥅ (g, 1)
+  (g, 1) ⥅ (ite, 3)
+  (ite, 1) ⥅ (c, 2)
   c
 end
 
 "f(x,y) = (x+y) + (x+y)"
 function triple_add()
   c = CompArrow(:xyxy, 2, 1)
-  x, y, z = ports(c)
+  x, y, z = ⬧(c)
   a1 = Arrows.add_sub_arr!(c, Arrows.AddArrow())
   a2 = Arrows.add_sub_arr!(c, Arrows.AddArrow())
   a3 = Arrows.add_sub_arr!(c, Arrows.AddArrow())
-  link_ports!((c, 1), (a1, 1))
-  link_ports!((c, 1), (a2, 1))
-  link_ports!((c, 2), (a1, 2))
-  link_ports!((c, 2), (a2, 2))
-  link_ports!((a1, 1), (a3, 1))
-  link_ports!((a2, 1), (a3, 2))
-  link_ports!((a3, 1), (c, 1))
+  (c, 1) ⥅ (a1, 1)
+  (c, 1) ⥅ (a2, 1)
+  (c, 2) ⥅ (a1, 2)
+  (c, 2) ⥅ (a2, 2)
+  (a1, 1) ⥅ (a3, 1)
+  (a2, 1) ⥅ (a3, 2)
+  (a3, 1) ⥅ (c, 1)
   c
 end
 
 function test_two_op()
   carr = CompArrow(:xyab, [:x, :y], [:a, :b])
-  x, y, a, b = sub_ports(carr)
+  x, y, a, b = ⬨(carr)
   z = x + y
   c = y * z
   c ⥅ a
@@ -159,7 +158,7 @@ end
 
 function cond_arr_eq()
   c = CompArrow(:xyx, [:x, :y], [:z])
-  x, y, z = ports(c)
+  x, y, z = ⬧(c)
   eq = add_sub_arr!(c, EqualArrow())
   ite = add_sub_arr!(c, CondArrow())
   x ⥅ (eq, 1)

--- a/test/tests/assert.jl
+++ b/test/tests/assert.jl
@@ -3,7 +3,7 @@ using Arrows
 
 function test_assert()
   carr = CompArrow(:xyx20, [:x, :y], [:z])
-  x, y, z = sub_ports(carr)
+  x, y, z = ⬨(carr)
   a = (2x + y)
   assert!(y > 100)
   a ⥅ z

--- a/test/tests/comparrow.jl
+++ b/test/tests/comparrow.jl
@@ -9,10 +9,10 @@ function test_rem_sub_arr()
   rem_sub_arr!(sarrs[1])
   @test !is_valid(arr)
   cosarr = add_sub_arr!(arr, CosArrow())
-  x, y = sub_ports(arr)
-  a, b = sub_ports(cosarr)
-  link_ports!(x, a)
-  link_ports!(b, y)
+  x, y = ⬨(arr)
+  a, b = ⬨(cosarr)
+  x ⥅ a
+  b ⥅ y
   @test is_valid(arr)
 end
 
@@ -30,14 +30,14 @@ test_replace_sub_arr()
 function test_compcall()
   f(x) = sin((x * x + x) / x)
   carr = CompArrow(:test, [:x], [:y])
-  x, y = sub_ports(carr)
+  x, y = ⬨(carr)
   g(x) = f(f(f(f(x))))
   g(x)
   num_sub_arrows(carr)
 
   # Try instead with CompCall
   carr = CompArrow(:test, [:x], [:y])
-  x, y = sub_ports(carr)
+  x, y = ⬨(carr)
   out, = compcall(f, compcall(f, (compcall(f, compcall(f, x)))))
   out ⥅ y
   @test is_valid(carr)
@@ -48,7 +48,7 @@ end
 function test_inner_sub_ports(carr::CompArrow)
   sprts = inner_sub_ports(carr)
   for sarr in sub_arrows(carr)
-    for sprt in sub_ports(sarr)
+    for sprt in ⬨(sarr)
       if sprt ∉ sprts
         @show deref(sprt)
         false

--- a/test/tests/ordered_sports.jl
+++ b/test/tests/ordered_sports.jl
@@ -7,9 +7,9 @@ using Base.Test
 function test_ordered()
   carr = TestArrows.xy_plus_x_arr()
   s_star, s_plus = sub_arrows(carr)
-  sport1 = sub_ports(s_plus)[3]
-  sport2 = sub_ports(s_star)[3]
-  z = sub_ports(carr)[3]
+  sport1 = ⬨(s_plus)[3]
+  sport2 = ⬨(s_star)[3]
+  z = ⬨(carr)[3]
   sports = [sport1, sport2, z]
   order = order_sports(carr, sports)
   @test sports[order] == [sport2, sport1, z]
@@ -17,7 +17,7 @@ end
 
 function test_basic_order()
   carr = TestArrows.xy_plus_x_arr()
-  sports = sub_ports(carr)
+  sports = ⬨(carr)
   order = order_sports(carr, sports)
   @test sports[order] == sports
 end
@@ -25,7 +25,7 @@ end
 function test_invert_order()
   carr = TestArrows.xy_plus_x_arr()
   inv_carr =  invert(carr)
-  sports = sub_ports(inv_carr)
+  sports = ⬨(inv_carr)
   x, y, z = sports[1:3]
   order = order_sports(inv_carr, sports)
   @test sports[order[1]] == z

--- a/test/tests/overload.jl
+++ b/test/tests/overload.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 function test_overload()
   carr = CompArrow(:tester, [:x, :y], [:z])
-  x, y, z = sub_ports(carr)
+  x, y, z = ⬨(carr)
   (2x * y + x) ⥅ z
   @test is_valid(carr)
 end

--- a/test/tests/propagate.jl
+++ b/test/tests/propagate.jl
@@ -6,7 +6,7 @@ using Base.Test
 
 function test_propagate()
   carr = TestArrows.xy_plus_x_arr()
-  x, y, z = sub_ports(carr)
+  x, y, z = ⬨(carr)
   # Suppose we know the output has shape (1,2,3)
   shapes = Dict(z => Shape((1,2,3)))
   propagate!(carr, shapes)

--- a/test/tests/value.jl
+++ b/test/tests/value.jl
@@ -5,14 +5,14 @@ using Base.Test
 
 
 function test_src_value()
-  x,y,z = sub_ports(TestArrows.xy_plus_x_arr())
+  x,y,z = ⬨(TestArrows.xy_plus_x_arr())
   @test same(Arrows.SrcValue.(Arrows.out_neighbors(x)))
 end
 
 
 function test_const_1()
   carr = TestArrows.xy_plus_x_arr()
-  x,y,z = sub_ports(carr)
+  x,y,z = ⬨(carr)
   is_const = Dict(z => known_const)
   propagate!(carr, is_const, const_propagator!)
   @test haskey(is_const, x) == false
@@ -21,7 +21,7 @@ function test_const_1()
 end
 function test_const_2()
   carr = TestArrows.xy_plus_x_arr()
-  x,y,z = sub_ports(carr)
+  x,y,z = ⬨(carr)
   is_const = Dict(x => known_const, y => known_const)
   propagate!(carr, is_const, const_propagator!)
   @test haskey(is_const, x) == true
@@ -34,8 +34,8 @@ end
 function test_const_srcarrow()
   c = AddArrow() >> SinArrow()
   one = add_sub_arr!(c, SourceArrow(1))
-  x, y =  in_sub_port(c, 1), in_sub_port(c, 2)
-  link_ports!(out_sub_port(one, 1), y)
+  x, y =  ▹(c, 1), ▹(c, 2)
+  (one, 1) ⥅ y
   is_const = Dict{SubPort, Const}()
   propagate!(c, is_const, const_propagator!)
   @test haskey(is_const, y)
@@ -48,10 +48,10 @@ function test_const_recursive()
   propagate!(arr, is_const, const_propagator!)
   wrap, one, min, ite, eq, add = sub_arrows(arr)
   @test length(is_const) == 4
-  @test haskey(is_const, in_sub_port(eq, 2))
-  @test haskey(is_const, out_sub_port(one, 1))
-  @test haskey(is_const, in_sub_port(ite, 2))
-  @test haskey(is_const, in_sub_port(min, 2))
+  @test haskey(is_const, ▹(eq, 2))
+  @test haskey(is_const, ◂(one, 1))
+  @test haskey(is_const, ▹(ite, 2))
+  @test haskey(is_const, ▹(min, 2))
 end
 
 test_src_value()

--- a/test/tests/value.jl
+++ b/test/tests/value.jl
@@ -49,7 +49,7 @@ function test_const_recursive()
   wrap, one, min, ite, eq, add = sub_arrows(arr)
   @test length(is_const) == 4
   @test haskey(is_const, ▹(eq, 2))
-  @test haskey(is_const, ◂(one, 1))
+  @test haskey(is_const, ◃(one, 1))
   @test haskey(is_const, ▹(ite, 2))
   @test haskey(is_const, ▹(min, 2))
 end


### PR DESCRIPTION
This is part of #46. Uses of functions from the family of `port` were replaced by their symbols: ⬧, ⬨, ▸, ▹, ◂, ◃. Additinally, some calls to `link_port!` were replaced by ⥅