### PR TITLE
Remove SymUnion

### DIFF
--- a/src/Arrows.jl
+++ b/src/Arrows.jl
@@ -121,6 +121,7 @@ export
   port_id,
   add_sub_arr!,
   replace_sub_arr!,
+  rm_partially_loose_sub_arrows!,
   out_sub_port,
   out_sub_ports,
   inner_sub_ports,

--- a/src/sym/rewrite.jl
+++ b/src/sym/rewrite.jl
@@ -32,11 +32,11 @@ end
 
 function expand_θ(θ, sz::Size)::RefinedSym
   shape = get(sz)
-  symbols = Array{Arrows.SymUnion, ndims(sz)}(shape...)
+  symbols = Array{Arrows.SymbolicType, ndims(sz)}(shape...)
   for iter in eachindex(symbols)
     symbols[iter] = θ[iter]
   end
-  symbols |> sym_unsym |> RefinedSym
+  symbols |> RefinedSym
 end
 
 function symbol_in_ports!(arr::CompArrow, info::ConstraintInfo, initprops)
@@ -45,7 +45,7 @@ function symbol_in_ports!(arr::CompArrow, info::ConstraintInfo, initprops)
   info.is_θ_by_portn = (Vector{Bool} ∘ n▸)(arr)
   for (idx, sport) in enumerate(▹(arr))
     info.is_θ_by_portn[idx] = is(θp)(sport)
-    sym = SymUnion(sport)
+    sym = (sport |> deref |> name).name
     info.port_to_index[sym] = idx
     else_ = ()-> RefinedSym(sym)
     true_ = function(size)

--- a/src/sym/rewrite.jl
+++ b/src/sym/rewrite.jl
@@ -205,7 +205,7 @@ function find_assignments(info)
     special = (l, r) -> assign_special_if_possible(info, l, r)
     if !assign(left, right) && !assign(right, left)
       if !special(left, right) && !special(right, left)
-        push!(info.unsat, SymUnion(expr))
+        push!(info.unsat, expr)
       end
     end
   end

--- a/src/sym/sym.jl
+++ b/src/sym/sym.jl
@@ -1,12 +1,5 @@
-"`Union{Symbol, Expr}`, Either a variable an expression"
-mutable struct SymUnion
-  value
-end
 
 const SymbolicType = Union{Expr, Symbol, Number, AbstractArray, Tuple, NTuple}
-
-@invariant SymUnion value isa Union{Expr, Symbol} # FIXME: Why isn't this in type?
-@invariant SymUnion if value isa Union; value.head == :call else true end #FIXME< use implies
 
 # FIXME: Label these?
 token_name = :τᵗᵒᵏᵉⁿ
@@ -105,8 +98,6 @@ function sym_interpret(parr::PrimArrow, args::Vector{RefinedSym})::Vector
   preds = Set[arg.preds for arg in args]
   allpreds = union(dompreds, preds...)
 
-  @show outputs[1]
-  @show outputs
   # @show vars
   # @grab vars
   # @show parr

--- a/src/sym/sym.jl
+++ b/src/sym/sym.jl
@@ -3,42 +3,37 @@ mutable struct SymUnion
   value
 end
 
+const SymbolicType = Union{Expr, Symbol, Number, AbstractArray, Tuple, NTuple}
+
 @invariant SymUnion value isa Union{Expr, Symbol} # FIXME: Why isn't this in type?
 @invariant SymUnion if value isa Union; value.head == :call else true end #FIXME< use implies
 
 # FIXME: Label these?
 token_name = :τᵗᵒᵏᵉⁿ
-SymPlaceHolder() = SymUnion(token_name)
+SymPlaceHolder() = token_name
 
 "Refined Symbol ``{var | pred}``"
 struct RefinedSym # FIXME: This should really be called a RefinementExpr
-  var::SymUnion # base expression
-  preds::Set{SymUnion}  # Conjunction of predicates
+  var::SymbolicType # base expression
+  preds::Set{SymbolicType}  # Conjunction of predicates
 end
 
 
 struct SymbolProxy
-  var::SymUnion
+  var::SymbolicType
 end
 
 
 "(base) expression "
-as_expr(sym::SymUnion) = sym.value
+as_expr(sym::SymbolicType) = sym
 
 ""
-as_expr{N}(values::Union{NTuple{N, SymUnion}, AbstractArray{SymUnion, N}}) =
+as_expr{N}(values::Union{NTuple{N, SymbolicType}, AbstractArray{SymbolicType, N}}) =
   map(as_expr, values)
 
 "(base) expression of `ref`"
 as_expr(ref::Union{RefinedSym, SymbolProxy}) = as_expr(ref.var)
 
-"Convert `Tuple` of symbols into a `SymUnion` representing a Tuple"
-sym_unsym{N}(sym::NTuple{N, SymUnion}) = SymUnion(as_expr.(sym))
-
-"Convert `Array` of symbols into a `Symbol` representing a `Array`"
-sym_unsym{N}(sym::Array{SymUnion, N}) = SymUnion(as_expr.(sym))
-sym_unsym{N}(sym::Tuple{N, SymUnion}) = SymUnion(as_expr.(sym))
-sym_unsym(sym::SymUnion) = sym
 
 # Zen: This kind of object scares me
 mutable struct ConstraintInfo
@@ -46,65 +41,63 @@ mutable struct ConstraintInfo
   θs::Set{Union{Symbol, Expr}}
   is_θ_by_portn::Vector{Bool}
   mapping::DefaultDict
-  unsat::Set{SymUnion}
+  unsat::Set{SymbolicType}
   assignments::Dict
   specials::Dict
   assigns_by_portn::Vector
   unassigns_by_portn::Vector
   specials_by_portn::Vector
   inp::Vector{RefinedSym}
-  port_to_index::Dict{SymUnion, Number}
+  port_to_index::Dict{SymbolicType, Number}
   master_carr::CompArrow
   names_to_inital_sarr::Dict{Union{Symbol, Expr}, SubArrow}
   function ConstraintInfo()
     c = new()
     c.mapping = DefaultDict(Set{Expr})
-    c.unsat = Set{SymUnion}()
+    c.unsat = Set{SymbolicType}()
     c.assignments = Dict()
     c.specials = Dict()
     c.names_to_inital_sarr = Dict()
-    c.port_to_index = Dict{SymUnion, Number}()
+    c.port_to_index = Dict{SymbolicType, Number}()
     c
   end
 end
 
 "Expression `:(s[i])` for symbol `s` and index `i`"
-function getindex(s::SymbolProxy, i::Int)::SymUnion
+function getindex(s::SymbolProxy, i::Int)::SymbolicType
   # @show s, i
   # @assert false
   inner_getindex(v) = v
-  inner_getindex(v::Array) = getindex(v, i) # FIXME: This can never be called
+  # FIXME: This can never be called.
+  # jb: SymbolProxy is a proxy for SymbolicType
+  # is the proxee is an Array, then this will be actually be called
+  inner_getindex(v::Array) = getindex(v, i)
   inner_getindex(v::Union{Symbol, Expr}) = Expr(:ref, v, i)
-  s |> as_expr |> inner_getindex |> SymUnion
+  s |> as_expr |> inner_getindex
 end
 
 "Unconstrained Symbol"
-RefinedSym(sym::SymUnion) = RefinedSym(sym, Set{SymUnion}())
+RefinedSym(sym::SymbolicType) = RefinedSym(sym, Set{SymbolicType}())
 
-"`SymUnion` with name of `prps`"
-function SymUnion(prps::Props)
-  # TODO: Add Type assumption
-  ustring = string(name(prps))
-  SymUnion(Symbol(ustring))
-end
-
-SymUnion(sprt::SubPort) = sprt |> deref |> SymUnion
-SymUnion(prt::Port) = prt |> props |> SymUnion
 
 "`RefinedSymbol` with port_name of `prt`"
-RefinedSym(prt::Port) = RefinedSym(SymUnion(prt))
+RefinedSym(prt::Port) = RefinedSym(name(prps).name)
+RefinedSym(sprt::SubPort) = RefinedSym(sprt |> deref)
 
 function sym_interpret(x::SourceArrow{T}, args)::Vector{RefinedSym} where T
-  [RefinedSym(SymUnion(x.value))]
+  @show x
+  [RefinedSym(x.value)]
 end
 
 function sym_interpret(x::SourceArrow{<:Array}, args)::Vector{RefinedSym}
+  @show x
   # @assert false "why"
-  [RefinedSym(SymUnion(x.value))]
+  [RefinedSym(x.value)]
 end
 
 function sym_interpret(parr::PrimArrow, args::Vector{RefinedSym})::Vector
-  vars = [SymUnion.(as_expr(arg)) for arg in args]
+  vars = [as_expr(arg) for arg in args]
+  @show vars
   outputs = prim_sym_interpret(parr, vars...)
 
   # Find predicates from all outputs and conjoin constraints
@@ -112,6 +105,8 @@ function sym_interpret(parr::PrimArrow, args::Vector{RefinedSym})::Vector
   preds = Set[arg.preds for arg in args]
   allpreds = union(dompreds, preds...)
 
+  @show outputs[1]
+  @show outputs
   # @show vars
   # @grab vars
   # @show parr
@@ -120,7 +115,7 @@ function sym_interpret(parr::PrimArrow, args::Vector{RefinedSym})::Vector
   # @show preds
   # @show allpreds
   # attach all constraints to all symbolic outputs of parr
-  map((var -> RefinedSym(var, allpreds)) ∘ sym_unsym, outputs)
+  map(var -> RefinedSym(var, allpreds), outputs)
 end
 
 sym_interpret(sarr::SubArrow, args) = sym_interpret(deref(sarr), args)

--- a/src/sym/symprim.jl
+++ b/src/sym/symprim.jl
@@ -44,7 +44,11 @@ function s_var(xs::Vararg{<:Array})
 end
 
 
-"Generic Symbolic Interpret of `parr`"
+"""Generic Symbolic Interpret of `parr`
+We are leveraging the broadcasting made by `.`.
+If we know the shape of a port, we create a matrix and then we do symbolic
+evaluation on each element of the matrix.
+"""
 function prim_sym_interpret(parr::PrimArrow, args::SymbolicType...)::Vector{SymbolicType}
   @assert num_out_ports(parr) == 1
   ## TODO: only for scalars

--- a/src/sym/symprim.jl
+++ b/src/sym/symprim.jl
@@ -27,20 +27,16 @@ end
 ## Primitive Symbolc Interpretation
 
 # Zen: What is this?
-var(xs::Array{SymUnion}) = SymUnion(:())
-
-# function ifelse(i::SymbolicType, t::SymbolicType, e::SymbolicType)
-#   :(ifelse($(i), $(t), $(e)))
-# end
+var(xs::Array{SymbolicType}) = :()
 
 # Zen: what is thi?
 "[:a, :b, :c] -> `name([:a, :b, :c])`"
-function s_arrayed(xs::Array{SymUnion}, name::Symbol)
+function s_arrayed(xs::Array{SymbolicType}, name::Symbol)
   @show values = [x.value for x in xs]
   @assert false
 end
 
-s_mean(xs::Array{SymUnion}) = s_arrayed(xs, :mean)
+s_mean(xs::Array{SymbolicType}) = s_arrayed(xs, :mean)
 function s_var(xs::Vararg{<:Array})
   map(xs |> first |> eachindex) do iter
     s_arrayed([x[iter] for x in xs], :var)
@@ -50,13 +46,9 @@ end
 
 "Generic Symbolic Interpret of `parr`"
 function prim_sym_interpret(parr::PrimArrow, args::SymbolicType...)::Vector{SymbolicType}
-  @show typeof(args)
-  @show parr
   @assert num_out_ports(parr) == 1
   ## TODO: only for scalars
-  @show :asdfaafsd
   f = (function_args...)-> Expr(:call, name(parr), function_args...)
-  @show f.(args...)
   ex = [f.(args...),]
 end
 

--- a/src/sym/symprim.jl
+++ b/src/sym/symprim.jl
@@ -1,25 +1,27 @@
 ## Domain Predicates
 
 "If inputs satisfy `domainpred`icates then then `arr` is well defined on them"
-domainpreds(::Arrow, args...) = Set{SymUnion}() # by default assume no constraints
+domainpreds(::Arrow, args...) = Set{SymbolicType}() # by default assume no constraints
 
-function domainpreds{N}(::InvDuplArrow{N}, x1::SymUnion, xs::Vararg)
+function domainpreds{N}(::InvDuplArrow{N}, x1::SymbolicType, xs::Vararg)
   # All inputs to invdupl must be equal
   symbols = map(xs) do x
-    :($(x.value) == $(x1.value))
+    :($(x) == $(x1))
   end
-  Set{SymUnion}(SymUnion.(symbols))
+  Set{SymbolicType}(symbols)
 end
 
+"""each element of the first array must be equal to each element of each of the
+other arrays"""
 function domainpreds(::InvDuplArrow, x1::Array, xs::Vararg)
-  answer = Array{SymUnion, 1}()
+  answer = Array{SymbolicType, 1}()
   for x in xs
     for (left, right) in zip(x1, x)
-      e = :($(left.value) == $(right.value))
-      push!(answer, SymUnion(e))
+      e = :($(left) == $(right))
+      push!(answer, e)
     end
   end
-  Set{SymUnion}(answer)
+  Set{SymbolicType}(answer)
 end
 
 ## Primitive Symbolc Interpretation
@@ -27,15 +29,14 @@ end
 # Zen: What is this?
 var(xs::Array{SymUnion}) = SymUnion(:())
 
-function ifelse(i::SymUnion, t::SymUnion, e::SymUnion)
-  SymUnion(:(ifelse($(i.value), $( t.value), $(e.value))))
-end
+# function ifelse(i::SymbolicType, t::SymbolicType, e::SymbolicType)
+#   :(ifelse($(i), $(t), $(e)))
+# end
 
 # Zen: what is thi?
 "[:a, :b, :c] -> `name([:a, :b, :c])`"
 function s_arrayed(xs::Array{SymUnion}, name::Symbol)
   @show values = [x.value for x in xs]
-  @show SymUnion(:($(name)($(values))))
   @assert false
 end
 
@@ -48,48 +49,55 @@ end
 
 
 "Generic Symbolic Interpret of `parr`"
-function prim_sym_interpret(parr::PrimArrow, args::SymUnion...)::Vector{SymUnion}
+function prim_sym_interpret(parr::PrimArrow, args::SymbolicType...)::Vector{SymbolicType}
   @show typeof(args)
+  @show parr
   @assert num_out_ports(parr) == 1
-  ex = [SymUnion(Expr(:call, name(parr), args...)),]
+  ## TODO: only for scalars
+  @show :asdfaafsd
+  f = (function_args...)-> Expr(:call, name(parr), function_args...)
+  @show f.(args...)
+  ex = [f.(args...),]
 end
 
-prim_sym_interpret(::BroadcastArrow, x::SymUnion)::Vector{SymUnion} = [x,]
+prim_sym_interpret(::BroadcastArrow, x::SymbolicType)::Vector{SymbolicType} = [x,]
 
-function prim_sym_interpret{N}(::DuplArrow{N}, x::SymUnion)
+function prim_sym_interpret{N}(::DuplArrow{N}, x::SymbolicType)
   [x  for _ in 1:N]
 end
 
-prim_sym_interpret(::IfElseArrow, i::SymUnion, t::SymUnion, e::SymUnion) =
-  [ifelse.(i, t, e)]
+# prim_sym_interpret(::IfElseArrow, i::SymbolicType, t::SymbolicType,
+#                    e::SymbolicType) =
+#   [ifelse.(i, t, e)]
 
 function prim_sym_interpret{N}(::InvDuplArrow{N},
-                                xs::Vararg{SymUnion, N})::Vector{SymUnion}
+                                xs::Vararg{SymbolicType, N})::Vector{SymbolicType}
   ## XXX: What are the consequences of just taking the first?
   [first(xs)]
 end
 
 function prim_sym_interpret{N}(::InvDuplArrow{N},
-                                xs::Vararg)::Vector{SymUnion}
-  [xs |> first |> sym_unsym,]
+                                xs::Vararg)::Vector{SymbolicType}
+  [xs |> first,]
 end
 
 function  prim_sym_interpret(::Arrows.ReshapeArrow,
-                              data::Array{Arrows.SymUnion,2},
-                              shape::Array{Arrows.SymUnion,1})
-  data = as_expr(data)
-  shape = as_expr(shape)
-  [SymUnion(reshape(data, shape)),]
+                              data::Array{SymbolicType,2},
+                              shape::Array{SymbolicType,1})
+  [reshape(data, shape),]
+end
 
+function  prim_sym_interpret(::Arrows.ReshapeArrow, data::SymbolicType,
+                            shape::SymbolicType)
+  shape = sym_unsym(shape)
+  expr = :(reshape($(data), $(shape)))
+  [expr,]
 end
 
 function prim_sym_interpret(::ScatterNdArrow, z, indices, shape)
-  indices = as_expr(indices)
-  shape = as_expr(shape)
-  z = sym_unsym(z)
   arrayed_sym = prim_scatter_nd(SymbolProxy(z), indices, shape,
                           SymPlaceHolder())
-  [sym_unsym(arrayed_sym),]
+  [arrayed_sym,]
 end
 
 function prim_sym_interpret{N}(::ReduceVarArrow{N}, xs::Vararg)
@@ -98,11 +106,4 @@ end
 
 function prim_sym_interpret{N}(::MeanArrow{N}, xs::Vararg)
   [s_arrayed([sym_unsym(x) for x in xs], :mean),]
-end
-
-function  prim_sym_interpret(::Arrows.ReshapeArrow, data::Arrows.SymUnion,
-                            shape)
-  shape = sym_unsym(shape)
-  expr = :(reshape($(data.value), $(shape.value)))
-  [SymUnion(expr),]
 end


### PR DESCRIPTION
This structure was working as a type alias while obscuring the code intention. 
Now we create a explicit `Union`